### PR TITLE
reverting daqcan forwarding to what worked on the 5e

### DIFF
--- a/src/FlexCAN_handle.cpp
+++ b/src/FlexCAN_handle.cpp
@@ -56,12 +56,12 @@ void InitCAN()
 
 int WriteCANToInverter(CAN_message_t &msg)
 {
-    // DaqCAN_.write(msg);
+    DaqCAN_.write(msg);
     return Inverter_CAN_.write(msg);
 }
 int WriteCANToAccumulator(CAN_message_t &msg)
 {
-    // DaqCAN_.write(msg);
+    DaqCAN_.write(msg);
     return AccumulatorCAN_.write(msg);
 }
 bool writeCANToJUSTAccumulator(CAN_message_t &msg)
@@ -82,13 +82,13 @@ int ReadDaqCAN(CAN_message_t &msg)
 int ReadInverterCAN(CAN_message_t &msg)
 {
     int ret = Inverter_CAN_.read(msg);
-    DaqCAN_.write(msg);
+    // DaqCAN_.write(msg);
     return ret;
 }
 
 int ReadAccumulatorCAN(CAN_message_t &msg)
 {
     int ret = AccumulatorCAN_.read(msg);
-    DaqCAN_.write(msg);
+    // DaqCAN_.write(msg);
     return ret;
 }

--- a/src/accumulator.cpp
+++ b/src/accumulator.cpp
@@ -57,6 +57,7 @@ void Accumulator::updateAccumulatorCAN()
     char lineBuffer[200];
     if (ReadAccumulatorCAN(rxMsg))
     {
+        WriteToDaqCAN(rxMsg);
         switch (rxMsg.id)
         {
         case (0x69):

--- a/src/inverter.cpp
+++ b/src/inverter.cpp
@@ -17,7 +17,7 @@ void Inverter::updateInverterCAN()
     CAN_message_t rxMsg2;
 
     // TODO Hey John delete this because I'm just putting it here to read CAN1
-    ReadDaqCAN(rxMsg2);
+    // ReadDaqCAN(rxMsg2);
 
     CAN_message_t rxMsg;
 


### PR DESCRIPTION
daq can forwarding code was changed and this broke the logs. here just reverting the forwarding code to how it worked before