### PR TITLE
change bms soc message id from placeholder to real

### DIFF
--- a/include/KS2eCAN.hpp
+++ b/include/KS2eCAN.hpp
@@ -28,7 +28,7 @@
 #define ID_VCU_WS_READINGS                                          0xC6
 #define ID_DASH_BUTTONS                                             0xEB
 #define ID_DASH_BUSVOLT                                             0xD4
-#define ID_BMS_SOC                                                  0x7FF //TODO make this real on the BMS
+#define ID_BMS_SOC                                                  0x6B3 //made this real!
 
 
 #define ID_BMS_INFO     0x6B1


### PR DESCRIPTION

![image](https://github.com/KSU-MS/KS6e-VCU-firmware/assets/32876429/481e2386-d954-4abd-83c8-a13b01b1eb95)

![image](https://github.com/KSU-MS/KS6e-VCU-firmware/assets/32876429/346989ce-7912-4a92-91b2-08fd1e14b238)
added message on the bms profile for state of charge, just have to set the ID on the vcu so that it is recognized and forwarded to dash