### PR TITLE
updated main job to also upload firmware artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: PlatformIO CI
 on: [push]
 
 jobs:
-  build:
+  build-and-upload:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,5 +26,5 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: teensy-hex
+          name: ${{ github.ref_name }}-teensy-hex
           path: .pio/build/teensy41/firmware.hex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,9 @@ jobs:
 
       - name: Build PlatformIO Project
         run: pio run
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: teensy-hex
+          path: .pio/build/teensy41/firmware.hex


### PR DESCRIPTION
this way people can just download artifacts of the appropriate version if they need to flash VCU
could come in handy when out on track with shit computers (toughbook) that have no prob downloading stuff but will struggle with compilation
![image](https://github.com/KSU-MS/KS6e-VCU-firmware/assets/32876429/29be38f5-71a3-410c-ae96-7839aa328ef6)
![image](https://github.com/KSU-MS/KS6e-VCU-firmware/assets/32876429/7600ce77-0cf8-4f77-b115-a637656a5bbe)
